### PR TITLE
[BUG/BE] Daily Creation Fails to Store Pre-Given Bullets

### DIFF
--- a/source/routes/create/daily.js
+++ b/source/routes/create/daily.js
@@ -35,7 +35,7 @@ module.exports = {
         // store a corresponding monthly-key
         monthKey: req.body.monthKey,
         // Stores the bullets in an array
-        bullets: req.body.bullet,
+        bullets: req.body.bullets,
       })
           .then((response) => {
             res.send(response);


### PR DESCRIPTION
Minor bug in dailies,  daily creation would be to fail if a bullet list was passed in - nothing would be stored.  Closes #59 